### PR TITLE
Fix zombie process on test failure

### DIFF
--- a/lib/mock_grpc.ex
+++ b/lib/mock_grpc.ex
@@ -95,8 +95,11 @@ defmodule MockGRPC do
     # dictionary, so we need to manually pass `test_key` over to the function
     # calls inside it.
     ExUnit.Callbacks.on_exit(fn ->
-      verify!(test_key)
-      stop_server(test_key)
+      try do
+        verify!(test_key)
+      after
+        stop_server(test_key)
+      end
     end)
 
     :ok


### PR DESCRIPTION
When a test failed, the server for that test wasn't being stopped causing a memory leak.

I couldn't find a way to write a test for this fix, because it requires a failing test in order to test it. 🤯 